### PR TITLE
Bot Downvote List Fixes

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -410,9 +410,13 @@ class admin(commands.Cog):
         await member.edit(voice_channel=None)
 
         if not duration:
-            DB.blacklist.put(member_id, b"1")
-            embed.title = "User Downvoted"
-            embed.description = f"**{member}** has been added to the downvote list"
+            if member.bot:
+                embed.title = "Cannot Downvote"
+                embed.description = "Bots cannot be added to the downvote list"
+            else:
+                DB.blacklist.put(member_id, b"1")
+                embed.title = "User Downvoted"
+                embed.description = f"**{member}** has been added to the downvote list"
             return await ctx.send(embed=embed)
 
         seconds = await self.end_date(duration)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -374,6 +374,7 @@ class admin(commands.Cog):
             How long to downvote the user for e.g 5d 10h 25m 5s
         """
         embed = discord.Embed(color=discord.Color.blurple())
+
         if not member:
             if list(DB.blacklist) == []:
                 embed.title = "No downvoted users"
@@ -395,6 +396,10 @@ class admin(commands.Cog):
                 )
 
             return await ctx.send(embed=embed)
+        
+        if member.bot:
+            embed.description = "Bots cannot be added to the downvote list"
+            return await ctx.send(embed=embed)
 
         member_id = f"{ctx.guild.id}-{str(member.id)}".encode()
 
@@ -410,13 +415,9 @@ class admin(commands.Cog):
         await member.edit(voice_channel=None)
 
         if not duration:
-            if member.bot:
-                embed.title = "Cannot Downvote"
-                embed.description = "Bots cannot be added to the downvote list"
-            else:
-                DB.blacklist.put(member_id, b"1")
-                embed.title = "User Downvoted"
-                embed.description = f"**{member}** has been added to the downvote list"
+            DB.blacklist.put(member_id, b"1")
+            embed.title = "User Downvoted"
+            embed.description = f"**{member}** has been added to the downvote list"
             return await ctx.send(embed=embed)
 
         seconds = await self.end_date(duration)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -396,7 +396,7 @@ class admin(commands.Cog):
                 )
 
             return await ctx.send(embed=embed)
-        
+
         if member.bot:
             embed.description = "Bots cannot be added to the downvote list"
             return await ctx.send(embed=embed)

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -366,7 +366,7 @@ class events(commands.Cog):
         else:
             guild = None
 
-        if await DB.get_blacklist(message.author.id, guild) == b"1":
+        if await DB.get_blacklist(message.author.id, guild) == b"1" and not message.author.bot:
             try:
                 await message.add_reaction("<:downvote:766414744730206228>")
             except:

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -205,7 +205,10 @@ class events(commands.Cog):
         reactions: List[discord.Reaction]
         """
         if await DB.get_blacklist(message.author.id, message.guild.id) == b"1":
-            await message.add_reaction("<:downvote:766414744730206228>")
+            try:
+                await message.add_reaction("<:downvote:766414744730206228>")
+            except discord.errors.HTTPException:
+                pass
 
     @commands.Cog.listener()
     async def on_voice_state_update(self, member, before, after):
@@ -366,12 +369,11 @@ class events(commands.Cog):
         else:
             guild = None
 
-        if await DB.get_blacklist(message.author.id, guild) == b"1" and not message.author.bot:
+        if await DB.get_blacklist(message.author.id, guild) == b"1":
             try:
                 await message.add_reaction("<:downvote:766414744730206228>")
-            except:
-                await message.add_reaction("⬇️")
-                print('Couldn\'t add downvote emoji to message.')
+            except discord.errors.HTTPException:
+                pass
 
     @commands.Cog.listener()
     async def on_member_update(self, before, after):

--- a/cogs/events.py
+++ b/cogs/events.py
@@ -367,7 +367,11 @@ class events(commands.Cog):
             guild = None
 
         if await DB.get_blacklist(message.author.id, guild) == b"1":
-            await message.add_reaction("<:downvote:766414744730206228>")
+            try:
+                await message.add_reaction("<:downvote:766414744730206228>")
+            except:
+                await message.add_reaction("⬇️")
+                print('Couldn\'t add downvote emoji to message.')
 
     @commands.Cog.listener()
     async def on_member_update(self, before, after):


### PR DESCRIPTION
- Prevents manual adding of bots to downvote list.
- Prevents downvoting bots messages if they are on the downvote list.
- Error checking for when trying to react with downvote emoji but not in server (only fixed 1 case, there are more instances).